### PR TITLE
Add groestlcoin_hash to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ try:
                 'web-static/share.html',
             ]),
         ],
+        install_requires=[
+            'groestlcoin_hash',
+        ],
 
         console=['run_p2pool.py'],
         options=dict(py2exe=dict(


### PR DESCRIPTION
`groestlcoin_hash` is now on PyPI, so it can be installed automatically. This needs testing before being merged.